### PR TITLE
Bug fix : use correct data type for access token

### DIFF
--- a/src/schema.lua
+++ b/src/schema.lua
@@ -5,6 +5,6 @@ return {
     content_type = { default = "application/json", enum = { "application/json" } },
     timeout = { default = 10000, type = "number" },
     keepalive = { default = 60000, type = "number" },
-    splunk_access_token = { default = "aaaaaaaa-bbbb-cccc-dddd-ffffffffffff", type="text"}
+    splunk_access_token = { default = "aaaaaaaa-bbbb-cccc-dddd-ffffffffffff", type="string"}
   }
 }


### PR DESCRIPTION
When trying to do a "kong migration bootstrap" / "kong migration up" to Kong-1.0.0rc1 this field causes the database migration to fail when set to "text".  Lua groks "string" rather than "text".

Signed-off-by: Scott Lovenberg <scott.lovenberg@optum.com>